### PR TITLE
Add extension path to the theme search path so that GIcon finds the file...

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -167,7 +167,8 @@ const TeaTime = new Lang.Class({
 
 function init(metadata) {
     // TODO: at some point, add translations
-    ;
+    let theme = imports.gi.Gtk.IconTheme.get_default();
+    theme.append_search_path(metadata.path);
 }
 
 let _TeaTime;


### PR DESCRIPTION
This should also make the install.sh unnecessary, I didn't want to remove it, though, as it may come in handy when installing the extension globally for all users (it has to be extended to allow that, of course).
