### PR TITLE
remove old countdown when new is selected

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -297,6 +297,7 @@ const TeaTime = new Lang.Class({
         this.actor.add_actor( this._bGraphicalCountdown
                               ? this._graphicalTimer : this._textualTimer);
 
+        if (this._idleTimeout != null) Mainloop.source_remove(this._idleTimeout);
         this._idleTimeout = Mainloop.timeout_add_seconds(dt, Lang.bind(this, this._doCountdown));
     },
     _getRemainingSec: function() {


### PR DESCRIPTION
When new countdown is selected from menu while other countdown is already active, the `_stopTime` variable is set according to the new countdown, but the original coundown remains active, so both countdowns finish at about the same time and both notifications are displayed.
Expected behavior would be to remove the previous countdown and leave active just the last one.