### PR TITLE
Allow reordering of entries in the settings dialog via drag and drop

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -124,6 +124,7 @@ const TeaTimePrefsWidget = new Lang.Class({
 			model: this._tealist,
 			expand: true
 		});
+		this.treeview.set_reorderable(true);
 		this.treeview.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE);
 		this.attach(this.treeview, 0, curRow, 3, 1);
 		curRow += 1;


### PR DESCRIPTION
This one-liner allows to re-order the entries in the settings dialog with the mouse.