### PR TITLE
Fixes tea cup animation for gnome 3.30

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -112,7 +112,12 @@ const TeaTimeFullscreenNotification = new Lang.Class({
 	},
 	show: function () {
 		if (typeof Layout.MonitorConstraint != 'undefined') {
-			this._monitorConstraint.index = global.screen.get_current_monitor()
+			// global.display was introduced in gnome-shell 3.30
+			if (typeof global.screen != 'undefined') {
+				this._monitorConstraint.index = global.screen.get_current_monitor();
+			} else {
+				this._monitorConstraint.index = global.display.get_current_monitor();
+			}
 		}
 		Main.pushModal(this._bin);
 		this._timeline.start();


### PR DESCRIPTION
'global.screen' seems to be replaced by 'global.display' in gnome-shell 3.30

https://www.reddit.com/r/gnome/comments/9kraax/globaldisplay_or_globalscreen_in_gnomeshell/
