### PR TITLE
Add gnome-shell 41-44 to supported shell versions

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,2 +1,2 @@
-{"shell-version": ["3.32", "3.34", "3.36", "40"], "uuid": "TeaTime@oleid.mescharet.de", "name": "TeaTime", "settings-schema": "org.gnome.shell.extensions.teatime", "gettext-domain": "TeaTime",
+{"shell-version": ["3.32", "3.34", "3.36", "40", "41", "42", "43", "44"], "uuid": "TeaTime@oleid.mescharet.de", "name": "TeaTime", "settings-schema": "org.gnome.shell.extensions.teatime", "gettext-domain": "TeaTime",
 "description": "A tea steeping timer\nCurrently in passive maintainance.\nGit repository: https://github.com/oleid/gnome-shell-teatime"}


### PR DESCRIPTION
As a teatime user I'm happy to see that teatime is still alive and that @zeners has added support for gnome-shell 40+.

I have just successfully tested teatime on gnome-shell 44. This updates metadata.json to indicate teatime supports gnome-shell up to version 44.

Note this pull-req which adds versions 41-44 obsoletes #60 which adds version 41-42 (which presumably was the last available version at the time #60 was created).